### PR TITLE
update from mattjhayes

### DIFF
--- a/config/examples/tc_policy.yaml.identity-1
+++ b/config/examples/tc_policy.yaml.identity-1
@@ -1,11 +1,10 @@
 #*** Traffic Classification Policy for nmeta
 #*** Written in YAML
-#*** Version 1.4
 #
 'PolicyRule 0':
     comment: OpenFlow Protocol Traffic
-    match_type: any
-    policy_conditions:
+    conditions:
+        match_type: any
         tcp_src: 6633
         tcp_dst: 6633
     actions:
@@ -13,8 +12,8 @@
         set_desc_tag: description="OpenFlow Protocol Traffic"
 'PolicyRule 1':
     comment: Explicitly set Iperf traffic to default class
-    match_type: any
-    policy_conditions:
+    conditions:
+        match_type: any
         tcp_src: 5001
         tcp_dst: 5001
     actions:
@@ -22,8 +21,8 @@
         set_desc_tag: description="Default Priority Iperf Traffic"  
 'PolicyRule 2':
     comment: SSH traffic
-    match_type: any
-    policy_conditions:
+    conditions:
+        match_type: any
         tcp_src: 22
         tcp_dst: 22
     actions:
@@ -31,8 +30,8 @@
         set_desc_tag: description="High Priority SSH Traffic"
 'PolicyRule 3':
     comment: Use Case Identity-1 - High Priority Business Traffic
-    match_type: any
-    policy_conditions:
+    conditions:
+        match_type: any
         identity_lldp_systemname_re: '.*\.audit\.example\.com'
     actions:
         set_qos_tag: QoS_treatment=high_priority

--- a/config/examples/tc_policy.yaml.identity-2
+++ b/config/examples/tc_policy.yaml.identity-2
@@ -4,8 +4,8 @@
 #
 'PolicyRule 0':
     comment: OpenFlow Protocol Traffic
-    match_type: any
-    policy_conditions:
+    conditions:
+        match_type: any
         tcp_src: 6633
         tcp_dst: 6633
     actions:
@@ -13,8 +13,8 @@
         set_desc_tag: description="OpenFlow Protocol Traffic"
 'PolicyRule 1':
     comment: Explicitly set Iperf traffic to default class
-    match_type: any
-    policy_conditions:
+    conditions:
+        match_type: any
         tcp_src: 5001
         tcp_dst: 5001
     actions:
@@ -22,8 +22,8 @@
         set_desc_tag: description="Default Priority Iperf Traffic"  
 'PolicyRule 2':
     comment: SSH traffic
-    match_type: any
-    policy_conditions:
+    conditions:
+        match_type: any
         tcp_src: 22
         tcp_dst: 22
     actions:
@@ -31,8 +31,8 @@
         set_desc_tag: description="High Priority SSH Traffic"
 'PolicyRule 3':
     comment: Use Case Identity-2 - High Priority Business Traffic
-    match_type: any
-    policy_conditions:
+    conditions:
+        match_type: any
         identity_lldp_systemname_re: '.*\.dev\.example\.com'
     actions:
         set_qos_tag: QoS_treatment=high_priority

--- a/config/examples/tc_policy.yaml.iperf-1
+++ b/config/examples/tc_policy.yaml.iperf-1
@@ -1,7 +1,7 @@
 'PolicyRule 1':
     comment: Iperf High Priority
-    match_type: any
-    policy_conditions:
+    conditions:
+        match_type: any
         tcp_src: 5001
         tcp_dst: 5001
     actions:
@@ -9,8 +9,8 @@
         set_desc_tag: description="Default Priority Iperf Traffic"
 'PolicyRule 2':
     comment: Iperf High Priority
-    match_type: any
-    policy_conditions:
+    conditions:
+        match_type: any
         tcp_src: 5002
         tcp_dst: 5002
     actions:
@@ -18,8 +18,8 @@
         set_desc_tag: description="High Priority Iperf Traffic"
 'PolicyRule 3':
     comment: Iperf Low Priority
-    match_type: any
-    policy_conditions:
+    conditions:
+        match_type: any
         tcp_src: 5003
         tcp_dst: 5003
     actions:

--- a/config/examples/tc_policy.yaml.nested-1
+++ b/config/examples/tc_policy.yaml.nested-1
@@ -1,0 +1,26 @@
+#*** Traffic Classification Policy for nmeta
+#*** Written in YAML
+#
+'PolicyRule 0':
+    comment: OpenFlow Protocol Traffic
+    conditions:
+        match_type: any
+        tcp_src: 6633
+        tcp_dst: 6633
+    actions:
+        set_qos_tag: QoS_treatment=system_priority
+        set_desc_tag: description="OpenFlow Protocol Traffic"
+'PolicyRule 1':
+    comment: Audit Division SSH traffic
+    conditions:
+        match_type: all
+        'conditions 1':
+            match_type: any
+            tcp_src: 22
+            tcp_dst: 22
+        'conditions 2':
+            match_type: any
+            identity_lldp_systemname_re: '.*\.audit\.example\.com'
+    actions:
+        set_qos_tag: QoS_treatment=high_priority
+        set_desc_tag: description="High Priority Audit Division SSH Traffic"

--- a/config/examples/tc_policy.yaml.payload-1
+++ b/config/examples/tc_policy.yaml.payload-1
@@ -1,7 +1,7 @@
 'PolicyRule 0':
     comment: OpenFlow Protocol Traffic
-    match_type: any
-    policy_conditions:
+    conditions:
+        match_type: any
         tcp_src: 6633
         tcp_dst: 6633
     actions:
@@ -9,8 +9,8 @@
         set_desc_tag: description="OpenFlow Protocol Traffic" 
 'PolicyRule 1':
     comment: SSH traffic
-    match_type: any
-    policy_conditions:
+    conditions:
+        match_type: any
         tcp_src: 22
         tcp_dst: 22
     actions:
@@ -18,8 +18,8 @@
         set_desc_tag: description="High Priority SSH Traffic"
 'PolicyRule 2':
     comment: Use Case Payload-1 - Low Priority FTP Traffic
-    match_type: any
-    policy_conditions:
+    conditions:
+        match_type: any
         payload_type: ftp
     actions:
         set_qos_tag: QoS_treatment=low_priority

--- a/config/examples/tc_policy.yaml.payload-2
+++ b/config/examples/tc_policy.yaml.payload-2
@@ -1,7 +1,7 @@
 'PolicyRule 0':
     comment: OpenFlow Protocol Traffic
-    match_type: any
-    policy_conditions:
+    conditions:
+        match_type: any
         tcp_src: 6633
         tcp_dst: 6633
     actions:
@@ -9,8 +9,8 @@
         set_desc_tag: description="OpenFlow Protocol Traffic" 
 'PolicyRule 1':
     comment: SSH traffic
-    match_type: any
-    policy_conditions:
+    conditions:
+        match_type: any
         tcp_src: 22
         tcp_dst: 22
     actions:

--- a/config/examples/tc_policy.yaml.payload-3
+++ b/config/examples/tc_policy.yaml.payload-3
@@ -1,7 +1,7 @@
 'PolicyRule 0':
     comment: OpenFlow Protocol Traffic
-    match_type: any
-    policy_conditions:
+    conditions:
+        match_type: any
         tcp_src: 6633
         tcp_dst: 6633
     actions:
@@ -9,8 +9,8 @@
         set_desc_tag: description="OpenFlow Protocol Traffic" 
 'PolicyRule 1':
     comment: SSH traffic
-    match_type: any
-    policy_conditions:
+    conditions:
+        match_type: any
         tcp_src: 22
         tcp_dst: 22
     actions:
@@ -18,8 +18,8 @@
         set_desc_tag: description="High Priority SSH Traffic"
 'PolicyRule 2':
     comment: FTP Control traffic
-    match_type: any
-    policy_conditions:
+    conditions:
+        match_type: any
         tcp_src: 21
         tcp_dst: 21
     actions:
@@ -27,8 +27,8 @@
         set_desc_tag: description="Low Priority FTP Control Traffic"
 'PolicyRule 3':
     comment: FTP Data traffic
-    match_type: any
-    policy_conditions:
+    conditions:
+        match_type: any
         tcp_src: 20
         tcp_dst: 20
     actions:

--- a/config/examples/tc_policy.yaml.static-1
+++ b/config/examples/tc_policy.yaml.static-1
@@ -1,11 +1,10 @@
 #*** Traffic Classification Policy for nmeta
 #*** Written in YAML
-#*** Version 1.4
 #
 'PolicyRule 0':
     comment: OpenFlow Protocol Traffic
-    match_type: any
-    policy_conditions:
+    conditions:
+        match_type: any
         tcp_src: 6633
         tcp_dst: 6633
     actions:
@@ -13,8 +12,8 @@
         set_desc_tag: description="OpenFlow Protocol Traffic"
 'PolicyRule 1':
     comment: Use Case Static-1 - High Priority Business Traffic
-    match_type: any
-    policy_conditions:
+    conditions:
+        match_type: any
         tcp_src: 1234
         tcp_dst: 1234
     actions:
@@ -22,8 +21,8 @@
         set_desc_tag: description="High Priority Business Traffic"  
 'PolicyRule 2':
     comment: SSH traffic
-    match_type: any
-    policy_conditions:
+    conditions:
+        match_type: any
         tcp_src: 22
         tcp_dst: 22
     actions:

--- a/config/examples/tc_policy.yaml.static-2
+++ b/config/examples/tc_policy.yaml.static-2
@@ -1,11 +1,10 @@
 #*** Traffic Classification Policy for nmeta
 #*** Written in YAML
-#*** Version 1.4
 #
 'PolicyRule 0':
     comment: OpenFlow Protocol Traffic
-    match_type: any
-    policy_conditions:
+    conditions:
+        match_type: any
         tcp_src: 6633
         tcp_dst: 6633
     actions:
@@ -13,8 +12,8 @@
         set_desc_tag: description="OpenFlow Protocol Traffic"
 'PolicyRule 1':
     comment: Use Case Static-1 - High Priority Business Traffic
-    match_type: any
-    policy_conditions:
+    conditions:
+        match_type: any
         tcp_src: 80 
         tcp_dst: 80 
     actions:
@@ -22,8 +21,8 @@
         set_desc_tag: description="High Priority Business Traffic"  
 'PolicyRule 2':
     comment: SSH traffic
-    match_type: any
-    policy_conditions:
+    conditions:
+        match_type: any
         tcp_src: 22
         tcp_dst: 22
     actions:

--- a/config/examples/tc_policy.yaml.statistical-control
+++ b/config/examples/tc_policy.yaml.statistical-control
@@ -1,7 +1,7 @@
 'PolicyRule 0':
     comment: SSH traffic
-    match_type: any
-    policy_conditions:
+    conditions:
+        match_type: any
         tcp_src: 22
         tcp_dst: 22
     actions:

--- a/config/examples/tc_policy.yaml.statistical1
+++ b/config/examples/tc_policy.yaml.statistical1
@@ -1,7 +1,7 @@
 'PolicyRule 0':
     comment: SSH traffic
-    match_type: any
-    policy_conditions:
+    conditions:
+        match_type: any
         tcp_src: 22
         tcp_dst: 22
     actions:
@@ -9,8 +9,8 @@
         set_desc_tag: description="High Priority SSH Traffic"
 'PolicyRule 1':
     comment: Basic Statistical Classifier
-    match_type: statistical
-    policy_conditions:
+    conditions:
+        match_type: any
         statistical_qos_bandwidth_1: on
     actions:
         pass_return_tags: true

--- a/config/tc_policy.yaml
+++ b/config/tc_policy.yaml
@@ -3,35 +3,26 @@
 #
 'PolicyRule 0':
     comment: OpenFlow Protocol Traffic
-    match_type: any
-    policy_conditions:
+    conditions:
+        match_type: any
         tcp_src: 6633
         tcp_dst: 6633
     actions:
         set_qos_tag: QoS_treatment=system_priority
         set_desc_tag: description="OpenFlow Protocol Traffic"
 'PolicyRule 1':
-    comment: Test of IP ranges and netmasks - High Priority Business Traffic
-    match_type: all
-    policy_conditions:
-        ip_src: 192.168.56.10-192.168.56.18
-        ip_dst: 192.168.57.40
+    comment: Use Case Static-1 - High Priority Business Traffic
+    conditions:
+        match_type: any
+        tcp_src: 1234
+        tcp_dst: 1234
     actions:
         set_qos_tag: QoS_treatment=high_priority
-        set_desc_tag: description="High Priority Business Traffic A->B"
+        set_desc_tag: description="High Priority Business Traffic"  
 'PolicyRule 2':
-    comment: Test of IP ranges and netmasks - High Priority Business Traffic
-    match_type: all
-    policy_conditions:
-        ip_src: 192.168.57.40
-        ip_dst: 192.168.56.10-192.168.56.18
-    actions:
-        set_qos_tag: QoS_treatment=high_priority
-        set_desc_tag: description="High Priority Business Traffic A<-B"  
-'PolicyRule 3':
     comment: SSH traffic
-    match_type: any
-    policy_conditions:
+    conditions:
+        match_type: any
         tcp_src: 22
         tcp_dst: 22
     actions:

--- a/tests_integration.py
+++ b/tests_integration.py
@@ -6,26 +6,41 @@ To run, type in nosetests in the nmeta directory
 
 import tc_policy
 from ryu.ofproto import ether
-from ryu.lib.packet import ethernet, arp, packet
+from ryu.lib.packet import ethernet, arp, packet, ipv4, tcp
 
 #==================== Policy Integration Tests ===============+==========
 #*** Instantiate classes:
 tc = tc_policy.TrafficClassificationPolicy \
                     ("DEBUG","DEBUG","DEBUG","DEBUG","DEBUG")
 #*** Test values for policy_conditions:
-policy_conditions1 = {'tcp_src': 6633, 'tcp_dst': 6633}
-policy_conditions2 = {'eth_src': '08:60:6e:7f:74:e7', 
+conditions_any_openflow = {'match_type': 'any', 
+                             'tcp_src': 6633, 'tcp_dst': 6633}
+conditions_all_openflow = {'match_type': 'all', 
+                             'tcp_src': 6633, 'tcp_dst': 6633}
+conditions_any_mac = {'match_type': 'any', 'eth_src': '08:60:6e:7f:74:e7', 
                          'eth_dst': '08:60:6e:7f:74:e8'}
-policy_conditions3 = {'ip_dst': '192.168.57.12', 'ip_src': '192.168.56.32'}
-policy_conditions4 = {'tcp_src': 22, 'tcp_dst': 22}
+conditions_all_mac = {'match_type': 'all', 'eth_src': '08:60:6e:7f:74:e7', 
+                         'eth_dst': '08:60:6e:7f:74:e8'}
+conditions_any_ip = {'match_type': 'any', 'ip_dst': '192.168.57.12', 
+                         'ip_src': '192.168.56.32'}
+conditions_any_ssh = {'match_type': 'any', 'tcp_src': 22, 'tcp_dst': 22}
+conditions_nested = {'conditions 2': {'match_type': 'any', 
+                'identity_lldp_systemname_re': '.*\\.audit\\.example\\.com'}, 
+                'conditions 1': {'match_type': 'any', 'tcp_src': 22, 
+                'tcp_dst': 22}, 'match_type': 'all'}
 
 #*** Check Match Validity Tests:
-def test_check_match():
+def test_check_conditions():
     #*** Test Packets:
-    pkt1 = build_packet_ARP()
-    tc._check_match(pkt1, policy_conditions1, 'any') == 0
-    tc._check_match(pkt1, policy_conditions2, 'any') == 1
-    tc._check_match(pkt1, policy_conditions2, 'all') == 0
+    pkt_arp = build_packet_ARP()
+    pkt_tcp_22 = build_packet_tcp_22()
+    tc._check_conditions(pkt_arp, conditions_any_openflow) == 0
+    tc._check_conditions(pkt_arp, conditions_all_openflow) == 0
+    tc._check_conditions(pkt_arp, conditions_any_mac) == 1
+    tc._check_conditions(pkt_arp, conditions_all_mac) == 0
+    tc._check_conditions(pkt_arp, conditions_nested) == 0
+    tc._check_conditions(pkt_tcp_22, conditions_any_ssh) == 1
+    tc._check_conditions(pkt_tcp_22, conditions_any_openflow) == 0
 
 #=========== Misc Functions to Generate Data for Unit Tests ===================
 
@@ -44,6 +59,34 @@ def build_packet_ARP():
     p = packet.Packet()
     p.add_protocol(e)
     p.add_protocol(a)
+    p.serialize()
+    print repr(p.data)  # the on-wire packet
+    return p
+
+def build_packet_tcp_22():
+    """
+    Build an SSH-like packet for use in tests.
+    """
+    #ethernet(dst='08:00:27:1e:98:88',ethertype=2048,src='00:00:00:00:00:02')
+    #ipv4(csum=25158,dst='192.168.57.40',flags=2,header_length=5,
+    # identification=58864,offset=0,option=None,proto=6,src='192.168.56.12',
+    # tos=0,total_length=60,ttl=64,version=4)
+    #tcp(ack=0,bits=2,csum=60347,dst_port=22,offset=10,
+    # option='\x02\x04\x05\xb4\x04\x02\x08\n\x00\x08\x16\x0f\x00\x00\x00\x00\x01\x03\x03\x06'
+    # ,seq=533918719,src_port=52656,urgent=0,window_size=29200)
+
+    e = ethernet.ethernet(dst='00:00:00:00:00:02',
+                      src='00:00:00:00:00:01',
+                      ethertype=2048)
+    i = ipv4.ipv4(version=4, header_length=5, tos=0, total_length=0, 
+                    identification=0, flags=0, offset=0, ttl=255, proto=0, 
+                    csum=0, src='10.0.0.1', dst='10.0.0.2', option=None)
+    t = tcp.tcp(src_port=1, dst_port=1, seq=0, ack=0, offset=0, bits=0, 
+                      window_size=0, csum=0, urgent=0, option=None)
+    p = packet.Packet()
+    p.add_protocol(e)
+    p.add_protocol(i)
+    p.add_protocol(t)
     p.serialize()
     print repr(p.data)  # the on-wire packet
     return p


### PR DESCRIPTION
fixes #1 . Note that this makes changes to tc_policy.yaml syntax. The attribute *policy_conditions* is renamed to *conditions* for brevity and the *match_type* statement is now within the conditions stanza. Nesting of conditions is now supported. In tc_policy the matching function is rewritten.